### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0](https://github.com/liamwh/HyprFocus/compare/v1.0.0...v1.1.0) - 2024-08-07
+
+### Added
+- Refactor to use hyprland-rs
+- Minimum Viable Product
+
+### Fixed
+- Fix swapping between multiple windows of desired application
+
+### Other
+- Add todo for identifying the launcher command
+- Improve how dependencies are captured in the changelog
+- Improve intro to HyprFocus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hyprfocus"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprfocus"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Open or focus your apps instantly"


### PR DESCRIPTION
## 🤖 New release
* `hyprfocus`: 1.0.0 -> 1.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0](https://github.com/liamwh/HyprFocus/compare/v1.0.0...v1.1.0) - 2024-08-07

### Added
- Refactor to use hyprland-rs
- Minimum Viable Product

### Fixed
- Fix swapping between multiple windows of desired application

### Other
- Add todo for identifying the launcher command
- Improve how dependencies are captured in the changelog
- Improve intro to HyprFocus
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).