### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/liamwh/HyprFocus/compare/v1.1.0...v1.1.1) - 2024-08-28
+
+### Other
+- *(deps)* bump serde from 1.0.208 to 1.0.209
+- Add HyprFocus logo to README.md
+
 ## [1.1.0](https://github.com/liamwh/HyprFocus/compare/v1.0.0...v1.1.0) - 2024-08-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hyprfocus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprfocus"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Open or focus your apps instantly"


### PR DESCRIPTION
## 🤖 New release
* `hyprfocus`: 1.1.0 -> 1.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.1](https://github.com/liamwh/HyprFocus/compare/v1.1.0...v1.1.1) - 2024-08-28

### Other
- *(deps)* bump serde from 1.0.208 to 1.0.209
- Add HyprFocus logo to README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).